### PR TITLE
Fix updating *http.ServerMux when file change is observed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,12 @@ lint:
 	go fmt ./...
 
 test:
-	go run main.go -f build/test.yaml
-testh:
-	go run main.go -h
+	go test -v -race -covermode atomic ./...
+	@echo "all tests passed"
+
 testv:
 	go run main.go -f build/test.yaml -v
+
 testvw:
 	go run main.go -f build/test.yaml -v -w
 

--- a/build/test.yaml
+++ b/build/test.yaml
@@ -14,6 +14,8 @@ weblisteners:                             # N array of web listeners...
         responseheaders:                  # N array of headers to pass
           - headerkey: "content-type"     # Header Key
             headervalue: "text/plain"     # Header Value
+          #- headerkey: "test"
+          #  headervalue: "123"
         responsecode: 200                 # Response code to return
         responsebodytype: "inline"        # Type of content to return. use "responsebody" to return static content. Possible values are "static", "proxy", and "file"
         responsebody: "You're in the root" # Body of response to return, can be a file if responsebodytype is set to "file"
@@ -56,4 +58,4 @@ weblisteners:                             # N array of web listeners...
             headervalue: "text/html"
         responsebodytype: "file"        
         responsecode: 200
-        responsebody: "build/test.html"s
+        responsebody: "build/test.html"

--- a/build/test.yaml
+++ b/build/test.yaml
@@ -14,8 +14,6 @@ weblisteners:                             # N array of web listeners...
         responseheaders:                  # N array of headers to pass
           - headerkey: "content-type"     # Header Key
             headervalue: "text/plain"     # Header Value
-          #- headerkey: "test"
-          #  headervalue: "123"
         responsecode: 200                 # Response code to return
         responsebodytype: "inline"        # Type of content to return. use "responsebody" to return static content. Possible values are "static", "proxy", and "file"
         responsebody: "You're in the root" # Body of response to return, can be a file if responsebodytype is set to "file"

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func handleConfigFileRefresh(fileEventChannel chan co.FileChangedEvent, listener
 	for l := range fileEventChannel {
 		co.LogVerbose(fmt.Sprintf("Config file \"%s\" was changed. Was: %s is: %s", l.FileName, l.FileHashBeforeChange, l.FileHashAfterChange), co.MSGTYPE_WARN)
 		ser.ClearAllListeners(listenerCommandChannel)
-		handleListenersFromFile(listenerCommandChannel, listenerResponseChannel, filePath) 
+		handleListenersFromFile(listenerCommandChannel, listenerResponseChannel, filePath)
 	}
 }
 
@@ -71,7 +71,7 @@ var banner string = `
 
 func main() {
 	fmt.Println(banner)
-	
+
 	// Ensure we have some calling arugments, or something being passed!
 	if len(os.Args) <= 0 {
 		fmt.Println("Please use the -h or --help switches for help.")
@@ -80,11 +80,13 @@ func main() {
 
 	// Handle global arguments
 	watchConfigFile := co.ArgSliceContains(os.Args, "-w") // Defines if we expect the config file(s) to dynamically update the configuration of the listeners etc.
-	if co.ArgSliceContainsInTerms(os.Args, []string{"-h","-help","--h","--help"}) {printHelp()} // Prints help if we need it :)
+	if co.ArgSliceContainsInTerms(os.Args, []string{"-h", "-help", "--h", "--help"}) {
+		printHelp()
+	} // Prints help if we need it :)
 
 	// Handle -f
 	m, params := co.ArgSliceSwitchParameters(os.Args, "-f")
-	if (m) {
+	if m {
 		fileWatcherChannel := make(chan co.FileChangedEvent)
 		listenerCommandChannel := make(chan ser.ListenerCommandPacket)
 		listenerResponseChannel := make(chan ser.ListenerResponse)
@@ -106,6 +108,4 @@ func main() {
 			log.Println(listenResponse)
 		}
 	}
-
-
 }

--- a/pkg/common/argextensions.go
+++ b/pkg/common/argextensions.go
@@ -6,8 +6,8 @@ import (
 
 // Search arguments for an existing switch, returns true if it finds your switch, returns false otherwise.
 func ArgSliceContains(args []string, switchTerm string) (switchTermMatched bool) {
-	for _, i:=range args {
-		if (i == switchTerm) {
+	for _, i := range args {
+		if i == switchTerm {
 			return true
 		}
 	}
@@ -16,18 +16,18 @@ func ArgSliceContains(args []string, switchTerm string) (switchTermMatched bool)
 
 // Search arguments for a slice of switches, if one is found, returns true, returns flase otherwise.
 func ArgSliceContainsInTerms(args []string, switchTerms []string) (switchTermMatched bool) {
-	for _, switchTerm:=range switchTerms {
+	for _, switchTerm := range switchTerms {
 		return ArgSliceContains(args, switchTerm)
 	}
 	return false
 }
 
 // Search arguments for an existing switch, returns true if it finds your switch, along with any trailing parameters, returns false,nil otherwise.
-func ArgSliceSwitchParameters(args []string, switchTerm string) (switchTermMatched bool, trailingParameters[]string) {
+func ArgSliceSwitchParameters(args []string, switchTerm string) (switchTermMatched bool, trailingParameters []string) {
 	params := []string{}
-	for i, arg:=range args {
-		if (arg == switchTerm) {
-			for p := i+1; p<len(args); p++ {
+	for i, arg := range args {
+		if arg == switchTerm {
+			for p := i + 1; p < len(args); p++ {
 				if !strings.Contains(args[p], "-") {
 					params = append(params, args[p])
 				}

--- a/pkg/server/listenerhandlers.go
+++ b/pkg/server/listenerhandlers.go
@@ -3,6 +3,7 @@ package server
 import "github.com/google/uuid"
 
 type ValidListenerCommand string
+
 const (
 	VLC_Close ValidListenerCommand = "close"
 	VLC_Pause ValidListenerCommand = "pause"
@@ -10,8 +11,9 @@ const (
 
 type ListenerCommandPacket struct {
 	Identifier uuid.UUID
-	Command ValidListenerCommand
+	Command    ValidListenerCommand
 }
 
 type ListenerResponse string
-func String(re ListenerResponse) string {return string(re)}
+
+func String(re ListenerResponse) string { return string(re) }

--- a/pkg/server/listeners.go
+++ b/pkg/server/listeners.go
@@ -21,9 +21,11 @@ func getListenerContent(binding se.ResponseBinding) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("getListenerContent: %w", err)
 		}
+
 		return c, nil
 	}
-	return "", fmt.Errorf("getListenerContent(): response type does not match known type of inline, file or proxy.")
+
+	return "", fmt.Errorf("getListenerContent(): response type does not match known type of inline, file or proxy")
 }
 
 func createListenerBinding(commandChannel chan ListenerCommandPacket, responseChannel chan ListenerResponse, binding se.ResponseBinding, sMux *http.ServeMux, threaduuid uuid.UUID) error {
@@ -110,12 +112,15 @@ var listenerRegister []uuid.UUID
 
 func ClearAllListeners(commandChannel chan ListenerCommandPacket) {
 	co.LogVerbose("Closing all listener threads...", co.MSGTYPE_WARN)
+
 	for _, thread := range listenerRegister {
 		co.LogVerbose(fmt.Sprintf("Closing listener thread %s...", thread), co.MSGTYPE_WARN)
 		commandChannel <- ListenerCommandPacket{Identifier: uuid.UUID(thread), Command: VLC_Close}
 	}
+
 	co.LogVerbose("Refreshing server Mux...", co.MSGTYPE_WARN)
-	sMux = http.NewServeMux()
+
+	*sMux = *http.NewServeMux()
 }
 
 func EstablishListener(commandChannel chan ListenerCommandPacket, responseChannel chan ListenerResponse, ls se.UnmarshalledRootSettingWebListener) error {

--- a/pkg/settings/unmarshalsettings_test.go
+++ b/pkg/settings/unmarshalsettings_test.go
@@ -1,0 +1,145 @@
+package settings_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/nrexception/mockapi/pkg/settings"
+)
+
+func TestResponseHeaders_Validate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		key           string
+		value         string
+		expectedError bool
+	}{
+		{
+			name:          "no key or value",
+			key:           "",
+			value:         "",
+			expectedError: true,
+		},
+		{
+			name:          "no key",
+			key:           "",
+			value:         "value",
+			expectedError: true,
+		},
+		{
+			name:          "no value",
+			key:           "key",
+			value:         "",
+			expectedError: true,
+		},
+		{
+			name:          "key and value",
+			key:           "key",
+			value:         "value",
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			header := &settings.ResponseHeader{
+				Key:   tc.key,
+				Value: tc.value,
+			}
+
+			err := header.Validate()
+			if (err != nil) != tc.expectedError {
+				t.Errorf("unexpected error response: %v", err)
+			}
+		})
+	}
+}
+
+func TestBodyType_String(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		bodyType settings.BodyType
+	}{
+		{
+			name:     "file",
+			bodyType: settings.File,
+		},
+		{
+			name:     "inline",
+			bodyType: settings.Inline,
+		},
+		{
+			name:     "proxy",
+			bodyType: settings.Proxy,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.bodyType.String()
+			want := string(tc.bodyType)
+
+			if got != want {
+				t.Errorf("unexpected string representation:\ngot: %s\nwant:%s", got, want)
+			}
+		})
+	}
+}
+
+func TestResponseBinding_Validate(t *testing.T) {
+	t.Parallel()
+
+	// TODO: Add more test cases
+	testCases := []struct {
+		name             string
+		path             string
+		responseHeaders  []settings.ResponseHeader
+		responseCode     int
+		responseBody     string
+		responseBodyType settings.BodyType
+		expectedError    bool
+	}{
+		{
+			name:             "file",
+			path:             "/",
+			responseHeaders:  []settings.ResponseHeader{{Key: "key", Value: "value"}},
+			responseCode:     http.StatusOK,
+			responseBody:     "somefile.json",
+			responseBodyType: settings.File,
+			expectedError:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			binding := &settings.ResponseBinding{
+				Path:             tc.path,
+				ResponseHeaders:  tc.responseHeaders,
+				ResponseCode:     tc.responseCode,
+				ResponseBody:     tc.responseBody,
+				ResponseBodyType: tc.responseBodyType,
+			}
+
+			err := binding.Validate()
+			if (err != nil) != tc.expectedError {
+				t.Errorf("unexpected error response: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change will keep the original address of the `*http.ServeMux` and just update the value at that address. The HTTP server will be able to reflect the changes because it's holding on to the original address.

This PR should be merged after #5.

Resolves #6.