### PR TITLE
Add CI with GitHub Actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,33 @@
+---
+name: pull_request
+on:
+  pull_request:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          check-latest: true
+
+      - name: Download dependencies
+        run: |
+          go mod tidy
+          go mod download
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.55
+
+      - name: Run tests
+        run: make test
+
+      - name: Build binaries
+        run: make build


### PR DESCRIPTION
This change will add CI to the project for future pull requests to all branches.

It will checkout the code, set up Go, run golangci-lint to lint the project, run unit tests, and attempt to build the binaries.

If any of these fail, we can quickly catch and fix the issues before merging.

You might find that satisfying golangci-lint to be annoying, but I promise you from years of experience that the suggestions it provides will make your projects better, and make you a better Go programmer.

Resolves #4